### PR TITLE
Fixed the OID including ErrorIndex issue

### DIFF
--- a/bin/sensu-trapd
+++ b/bin/sensu-trapd
@@ -1,0 +1,88 @@
+#!/bin/sh
+#
+# Start/stop the sensu-trapd service
+#
+# chkconfig: 2345 90 60
+
+RETVAL=0
+prog="sensu-trapd"
+exec="/opt/sensu-trapd/bin/$prog"
+prog_path="/var/www/gslbconsole/servicemonitor"
+lockfile=/var/lock/subsys/sensu-trapd
+exec_user="root"
+
+cfg_file=/opt/sensu-trapd/conf/config.json
+log_level=DEBUG
+
+PID=`ps -ef | grep sensu-trapd | grep python | awk '{print $2}'`
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+
+start() {
+    [ -x $exec ] || exit 5
+    echo -n $"Starting $prog: "
+    $exec -c $cfg_file -l $log_level > /dev/null 2>&1 &
+    retval=$?
+    sleep 2
+    PID=`ps -ef | grep sensu-trapd | grep python | awk '{print $2}'` 
+    echo "${PID}"
+    [ $retval -eq 0 ] && touch $lockfile
+}
+
+stop() {
+    if [ $UID -ne 0 ] ; then
+        echo "User has insufficient privilege."
+        exit 4
+    fi
+    echo -n $"Stopping $prog: "
+	if [ "X${PID}" != 'X' ]; then
+		kill -9 ${PID}
+		RETVAL=3
+	else
+		failure $"Stopping $prog"
+	fi
+    retval=$?
+    sleep 2
+    echo "Done"
+    [ $retval -eq 0 ] && rm -f $lockfile
+}
+
+restart() {
+    status && stop
+    start
+}
+
+
+status() {
+    if [ "X${PID}" = 'X' ]; 
+    then
+    	echo "${prog} is not running"
+    	return 1
+    else
+    	echo "${prog} is running : ${PID}"
+    	return 0
+    fi
+}
+
+case "$1" in
+    start)
+        status && exit 0
+        $1
+        ;;
+    stop)
+        status || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        status
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart}"
+        exit 2
+esac
+exit $?

--- a/bin/sensu-trapd
+++ b/bin/sensu-trapd
@@ -23,7 +23,7 @@ PID=`ps -ef | grep sensu-trapd | grep python | awk '{print $2}'`
 start() {
     [ -x $exec ] || exit 5
     echo -n $"Starting $prog: "
-    $exec -c $cfg_file -l $log_level > /dev/null 2>&1 &
+    $exec -c $cfg_file -l $log_level -f > /dev/null 2>&1 &
     retval=$?
     sleep 2
     PID=`ps -ef | grep sensu-trapd | grep python | awk '{print $2}'` 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ distro = platform.dist()[0]
 data_files = list()
 data_files.append(('', ['requirements.txt', 'version.txt']))
 data_files.append(('', ['conf/config.json.default', 'conf/traps.json.default']))
+data_files.append(('/etc/init.d', ['bin/sensu-trapd']))
 
 def get_version():
     """ 

--- a/src/sensu/snmp/event.py
+++ b/src/sensu/snmp/event.py
@@ -1,21 +1,30 @@
 import json
-
+import time
 
 class TrapEvent(object):
 
     EVENT_SEVERITY = {"CRITICAL": 2, "WARNING": 1, "OK": 0}
 
-    def __init__(self, name, output, status, handlers):
+    def __init__(self, name, output, status, handlers, 
+                 environment=None, servicetag=None, mail_to=None):
         self.name = name
         self.output = output
         self.status = status
         self.handlers = handlers
+        self.executed = int(time.time())
+        self.environment = environment
+        self.servicetag = servicetag
+        self.mail_to = mail_to
 
     def to_json(self):
         return json.dumps({'name': self.name,
                            'output': self.output,
                            'status': self.status,
-                           'handlers': self.handlers})
+                           'handlers': self.handlers,
+                           'executed': self.executed,
+                           'environment': self.environment,
+                           'servicetag': self.servicetag,
+                           'mail_to': self.mail_to})
 
     def __repr__(self):
         return "<TrapEvent name:'%s' >" % (self.name)

--- a/src/sensu/snmp/handler.py
+++ b/src/sensu/snmp/handler.py
@@ -4,7 +4,9 @@ from sensu.snmp.log import log
 
 class TrapHandler(object):
 
-    def __init__(self, trap_type, trap_args, event_name, event_output, event_handlers, event_severity, predicates=None):
+    def __init__(self, trap_type, trap_args, event_name, 
+                 event_output, event_handlers, event_severity, 
+                 environment, servicetag, mail_to, predicates=None):
         if predicates is None:
             predicates = dict()
 
@@ -15,6 +17,10 @@ class TrapHandler(object):
         self.event_handlers = event_handlers
         self.event_severity = event_severity
         self.predicates = predicates
+        self.environment = environment
+        self.servicetag = servicetag
+        self.mail_to = mail_to
+            
 
     def handles(self, trap):
         if trap.oid == self.trap_type:
@@ -46,7 +52,10 @@ class TrapHandler(object):
 
     def transform(self, trap):
         substitutions = self._build_substitutions(trap)
-        return TrapEvent(self._do_substitutions(self.event_name, substitutions),
+        event = TrapEvent(self._do_substitutions(self.event_name, substitutions),
                          self._do_substitutions(self.event_output, substitutions),
                          self.event_severity,
-                         self.event_handlers)
+                         self.event_handlers,
+                         self.environment,
+                         self.servicetag,
+                         self.mail_to)

--- a/src/sensu/snmp/receiver.py
+++ b/src/sensu/snmp/receiver.py
@@ -145,7 +145,10 @@ class TrapReceiver(object):
                 else:
                     # all other values should be converted to mib symbol/modname
                     # and put in the trap_data dict
-                    trap_arg_oid = oid
+                    #trap_arg_oid = oid
+                    # For the case the faultIndex was added into the OID, we have to lookup 
+                    # the original OID from MIB instead of using the OID in the received packet directly.
+                    trap_arg_oid = self._mibs.lookup(module, symbol)
                     # convert value
                     trap_arg_value = self._mibs.lookup_value(module, symbol, val)
                     trap_args[trap_arg_oid] = trap_arg_value

--- a/src/sensu/snmp/server.py
+++ b/src/sensu/snmp/server.py
@@ -75,7 +75,15 @@ class SensuTrapServer(object):
         event_output = trap_handler_config['event']['output']
         event_handlers = trap_handler_config['event']['handlers']
         event_severity = parse_event_severity(trap_handler_config['event']['severity'])
-
+        environment = None
+        servicetag = None
+        mail_to = None
+        if trap_handler_config['event'].has_key('environment'):
+            environment = trap_handler_config['event']['environment']
+        if trap_handler_config['event'].has_key('servicetag'):
+            servicetag = trap_handler_config['event']['servicetag']
+        if trap_handler_config['event'].has_key('mail_to'):
+            mail_to = trap_handler_config['event']['mail_to']
         # TODO: parse predicates
 
         # Initialize TrapHandler
@@ -85,6 +93,9 @@ class SensuTrapServer(object):
                                     event_output,
                                     event_handlers,
                                     event_severity,
+                                    environment,
+                                    servicetag,
+                                    mail_to,
                                     None)
         return trap_handler
 


### PR DESCRIPTION
In CISCO server MIB, a faultindex is appended into OID if an error happens. 
In this case, we can not match the OID in received packet with the OID from the configuration( which was lookup from MIB directly). We have to lookup the (module, symbol) and lookup OID from MIB again before creating Trap object.

Thist pull request fixed the issue I reported "Trap arg does not match #3" one week ago.
